### PR TITLE
Feature/cr 204 (bis)

### DIFF
--- a/NtS.xsd
+++ b/NtS.xsd
@@ -1343,6 +1343,9 @@
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="target_group_code_enum">
+	<xs:annotation>
+		<xs:documentation>Values 'NNU' and 'WOC' are obsolete per CR-204.</xs:documentation>
+	</xs:annotation>
     <xs:restriction base="xs:string">
       <xs:maxLength value="3"/>
       <xs:enumeration value="ALL"/>
@@ -1352,13 +1355,14 @@
       <xs:enumeration value="PLE"/>
       <xs:enumeration value="CNV"/>
       <xs:enumeration value="PUS"/>
-      <xs:enumeration value="NNU"/>
       <xs:enumeration value="LOA"/>
       <xs:enumeration value="SMA"/>
       <xs:enumeration value="CND"/>
-      <xs:enumeration value="WOC"/>
       <xs:enumeration value="MOV"/>
       <xs:enumeration value="NMV"/>
+      <!-- obsolete values due to CR-204 but kept for backwards compatibility -->
+      <xs:enumeration value="NNU"/>
+      <xs:enumeration value="WOC"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="direction_code_enum">

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An overview of all changes to the NtS xsd is provided in this file.
 
 ### Changed
 - CR 203 - Addition of RIS_ID to NtS messages LocationType
+- CR 204 - Clean-up of unused codes and unusable codes for Voyage Calculation
 - CR 205 - Translation of content
 - CR 206 - Merge of FTM and ICEM
 - CR 207 - Use of iCalendar in Limitation Period


### PR DESCRIPTION
This branch feature was redone because CR204 and CR207 were conflicting.

Indeed, CR207 removed a whole section of the XSD (time interval) that CR204 was trying to modify. It would have worked, maybe, if CR204 was applied BEFORE CR207, but this was not the case.

I did CR204 again, ignoring the time interval part and only applying obsolete codes for NNU and WOC in the target group enumeration + update of the README.